### PR TITLE
Adding example for biblatex

### DIFF
--- a/bib/mybib.bib
+++ b/bib/mybib.bib
@@ -1,0 +1,48 @@
+%@Article{ArticleName,
+%    author                 ="",
+%    title                  ="",
+%    journal                ="",
+%    year                   ="",
+%    volume                 ="",
+%    pages                  ="",
+%    abstract               ="",
+%    issn                   ="",
+%    doi                    ="",
+%    url                    =""
+%}
+
+%@book{myTitle,
+%    Title                  = {},
+%    Author                 = {},
+%    Publisher              = {},
+%    Edition                = {},
+%    Pages                  = {},
+%    Language               = {},
+%    Organization           = {},
+%    Year                   = {},
+%    Month                  = {},
+%    howpublished           = {},
+%    Note                   = {},
+%
+%    Owner                  = {},
+%    Timestamp              = {}
+%}
+
+%@misc{website:Title,
+%    Title                  = {},
+%    Author                 = {},
+%    Publisher              = {},
+%    Edition                = {},
+%    Pages                  = {},
+%    Language               = {},
+%    Organization           = {},
+%    Year                   = {},
+%    Month                  = {},
+%    howpublished           = "\url{}",
+%    Note                   = {Accessed: },
+%
+%    Owner                  = {},
+%    Timestamp              = {}
+%
+%}
+


### PR DESCRIPTION
Adding a couple of examples to the biblatex in a way that makes it
faster to add a new source without first ressearching or remembering the
biblatex writing format.
Usually when using the template we start by adding examples for biblatex, it might as well be done right away.